### PR TITLE
fix plaintext pypi docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Uses `sphinx-build` to build the HTML documentation.
 
 ``flinx build -o`` opens a browser onto the documentation once it's been built.
 
-.. todo:: Currently this pollutes ``./docs``.
+.. warning:: TODO: Currently this pollutes ``./docs``.
 
 ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Documentation :: Sphinx",
     "Topic :: Software Development :: Documentation",
     ]
-description-file = "./README.rst"
+description-file = "README.rst"
 requires = ["click", "flit" , "Sphinx", "sphinx-autobuild"]
 # It's probably compatible with 3.0–3.4 too. I haven't tested it.
 requires-python = ">=3.5"


### PR DESCRIPTION
```
The file description seems not to be valid rst for PyPI; it will be interpreted as plain text                                                                                                                                                                      E-flit.validate
<string>:44: (ERROR/3) Unknown directive type "todo".

.. todo:: Currently this pollutes ``./docs``.

                                                                                                                                                             E-flit.validate
Config error: Invalid config values (see log)
```

```
Found 31 files tracked in git                                                                                                                                                                                                                                         I-flit.sdist
Traceback (most recent call last):
  File "/home/graingert/.virtualenvs/flit/bin/flit", line 8, in <module>
    sys.exit(main())
  File "/home/graingert/.virtualenvs/flit/lib/python3.8/site-packages/flit/__init__.py", line 170, in main
    main(args.ini_file, formats=set(args.format or []),
  File "/home/graingert/.virtualenvs/flit/lib/python3.8/site-packages/flit/build.py", line 46, in main
    sdist_file = sb.build(dist_dir, gen_setup_py=gen_setup_py)
  File "/home/graingert/.virtualenvs/flit/lib/python3.8/site-packages/flit/sdist.py", line 223, in build
    return Path(super().build(str(target_dir), gen_setup_py=gen_setup_py))
  File "/home/graingert/.virtualenvs/flit/lib/python3.8/site-packages/flit_core/sdist.py", line 181, in build
    files_to_add = self.apply_includes_excludes(self.select_files())
  File "/home/graingert/.virtualenvs/flit/lib/python3.8/site-packages/flit_core/sdist.py", line 154, in apply_includes_excludes
    raise Exception("Crucial files were excluded from the sdist: {}"
Exception: Crucial files were excluded from the sdist: ./readme.rst
```